### PR TITLE
Handle empty request

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -117,6 +117,14 @@ func callbackHandler(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, redirectURL, http.StatusFound)
 }
 
+
+func emptyHandler(w http.ResponseWriter, r *http.Request) {
+
+	// log.Println("Token:", access_token)
+	log.Println("I'm empty")
+	return;
+}
+
 func getAccessToken(code string, verifier string) (string, string) {
 	params := url.Values {
 		"client_id":     {"98fc1b94f1e445cebcfe067a505598ba"},
@@ -383,6 +391,10 @@ func main() {
 
 	http.HandleFunc("/analyzer", func(w http.ResponseWriter, r *http.Request) {
 		corsHandler.Handler(http.HandlerFunc(analyzerHandler)).ServeHTTP(w, r)
+	})
+
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		corsHandler.Handler(http.HandlerFunc(emptyHandler)).ServeHTTP(w, r)
 	})
 
 	http.ListenAndServe(":8080", nil)

--- a/server/main.go
+++ b/server/main.go
@@ -120,8 +120,7 @@ func callbackHandler(w http.ResponseWriter, r *http.Request) {
 
 func emptyHandler(w http.ResponseWriter, r *http.Request) {
 
-	// log.Println("Token:", access_token)
-	log.Println("I'm empty")
+	log.Println("website accessed with no handler")
 	return;
 }
 


### PR DESCRIPTION
When accessing the server's URL, if no handler is given, there is no response. For the client, the response is `404 page not found`. There is a log message now instead for the host confirming the app was accessed.

Maybe an opportunity to redirect the user?

![image](https://github.com/rmore4623/Spotify-Playlist-Widget/assets/36529608/ab479afa-e983-4793-9d13-f83bb8775ade)
